### PR TITLE
snowflake add hostname field

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,23 @@ This code is governed by a commercial license. To use it, you must follow refer 
 
 ## Configure Snowflake
 
-To connect your Snowflake database to Dreamfactory, you will need to specify:  
-1) Account  
+To connect your Snowflake database to Dreamfactory, you will need to specify:
+
+1) Hostname
+An optional hostname that can be used as an alternative to the snowflake default hostname.
+2) Account
 Account is the [hostname + region](https://docs.snowflake.com/en/user-guide/intro-regions.html#specifying-region-information-in-your-account-hostname) information.  
 You can just copy it from your snowflake database URL:  
 
 ![accountexample](https://img.in6k.com/screens/3caa9f72_2021.04.02.png)
 
 
-2) Username  
+3) Username
 Username that you use to login to your snowflake account or any other user with access to the database.
-3) Password  
-4) Database  
+4) Password
+5) Database
 Name of the database you want to connect to.
-5) Warehouse  
+6) Warehouse
 Name of the warehouse your database uses.
-6) Schema (optional)  
+7) Schema (optional)
 Schema of the database, PUBLIC by default.

--- a/src/Database/Connectors/SnowflakeConnector.php
+++ b/src/Database/Connectors/SnowflakeConnector.php
@@ -59,6 +59,10 @@ class SnowflakeConnector extends Connector implements ConnectorInterface
 
         $dsn = "snowflake:";
 
+        if (!empty($hostname)) {
+            $dsn .= "host={$hostname};";
+        }
+
         if (!empty($account)) {
             $dsn .= "account={$account};";
         }

--- a/src/Models/SnowflakeDbConfig.php
+++ b/src/Models/SnowflakeDbConfig.php
@@ -11,7 +11,7 @@ use DreamFactory\Core\SqlDb\Models\BaseSqlDbConfig;
  */
 class SnowflakeDbConfig extends BaseSqlDbConfig
 {
-    protected $appends = ['account', 'username', 'password', 'database', 'warehouse', 'schema', 'role'];
+    protected $appends = ['hostname', 'account', 'username', 'password', 'database', 'warehouse', 'schema', 'role'];
 
     protected $encrypted = ['username', 'password'];
 
@@ -19,7 +19,7 @@ class SnowflakeDbConfig extends BaseSqlDbConfig
 
     protected function getConnectionFields()
     {
-        return ['account', 'username', 'password', 'database', 'warehouse', 'schema', 'role'];
+        return ['hostname', 'account', 'username', 'password', 'database', 'warehouse', 'schema', 'role'];
     }
 
     public static function getDriverName()
@@ -31,6 +31,12 @@ class SnowflakeDbConfig extends BaseSqlDbConfig
     public static function getDefaultConnectionInfo()
     {
         $defaults = [
+            [
+                'name' => 'hostname',
+                'label' => 'Hostname',
+                'type' => 'string',
+                'description' => 'Snowflake hostname, This can be alternative snowflake hostname (Optional).'
+            ],
             [
                 'name' => 'account',
                 'label' => 'Account',

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -63,6 +63,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
     protected function checkHeaders(&$config)
     {
+        $this->substituteConfig('hostname', 'header', $config);
         $this->substituteConfig('account', 'header', $config);
         $this->substituteConfig('database', 'header', $config);
         $this->substituteConfig('schema', 'header', $config);
@@ -74,7 +75,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
     protected function checkUrlParams(&$config)
     {
-
+        $this->substituteConfig('hostname', 'url', $config);
         $this->substituteConfig('account', 'url', $config);
         $this->substituteConfig('database', 'url', $config);
         $this->substituteConfig('schema', 'url', $config);

--- a/src/Services/SnowflakeDb.php
+++ b/src/Services/SnowflakeDb.php
@@ -45,6 +45,7 @@ class SnowflakeDb extends SqlDb
         foreach ($paths as $pkey => $path) {
             if ($pkey !== '/' && isset($path['get']) && isset($path['get']['parameters'])) {
                 $newParams = [
+                    $this->getHeaderPram('hostname'),
                     $this->getHeaderPram('account'),
                     $this->getHeaderPram('username'),
                     $this->getHeaderPram('password'),


### PR DESCRIPTION
This change adds a new 'hostname' field to the snowflake connector configuration. The purpose of this addition is to accommodate scenarios where Snowflake is placed behind an application-level proxy. In such cases, the actual hostname for Snowflake is not snowflakecomputing, but rather the one associated with the application-level proxy.

UI wasn't tested due to missing license, however the PDO was tested.
