### PR TITLE
Add support for snowflakes ILIKE operator in the filter field

### DIFF
--- a/src/Enums/DbComparisonOperators.php
+++ b/src/Enums/DbComparisonOperators.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace DreamFactory\Core\Snowflake\Enums;
+
+use DreamFactory\Core\Enums\DbComparisonOperators as BaseDbComparisonOperators;
+
+
+/**
+ * DbComparisonOperators
+ * DB server-side filter comparison operator string constants
+ */
+class DbComparisonOperators extends BaseDbComparisonOperators
+{
+    //*************************************************************************
+    //	Constants
+    //*************************************************************************
+
+    /**
+     * @var string
+     */
+    const ILIKE = 'ILIKE';
+
+    public static function getParsingOrder()
+    {
+        $baseParsingOrder = parent::getParsingOrder();
+        $likePos = array_search(static::LIKE, $baseParsingOrder);
+        array_splice($baseParsingOrder, $likePos, 0, static::ILIKE);
+        return $baseParsingOrder;
+    }
+}

--- a/src/Resources/SnowflakeTable.php
+++ b/src/Resources/SnowflakeTable.php
@@ -2,9 +2,13 @@
 namespace DreamFactory\Core\Snowflake\Resources;
 
 use DB;
+use DreamFactory\Core\Database\Schema\ColumnSchema;
+use DreamFactory\Core\Database\Enums\DbFunctionUses;
 use DreamFactory\Core\Enums\ApiOptions;
+use DreamFactory\Core\Enums\DbLogicalOperators;
 use DreamFactory\Core\Exceptions\BadRequestException;
 use DreamFactory\Core\Exceptions\BatchException;
+use DreamFactory\Core\Snowflake\Enums\DbComparisonOperators;
 use DreamFactory\Core\SqlDb\Resources\Table;
 use Arr;
 
@@ -83,6 +87,147 @@ class SnowflakeTable extends Table
         }
 
         return $out;
+    }
+
+    /**
+     * @param string         $filter
+     * @param array          $out_params
+     * @param ColumnSchema[] $fields_info
+     * @param array          $in_params
+     *
+     * @return string
+     * @throws \DreamFactory\Core\Exceptions\BadRequestException
+     * @throws \Exception
+     */
+    protected function parseFilterString($filter, array &$out_params, $fields_info, array $in_params = [])
+    {
+        if (empty($filter)) {
+            return null;
+        }
+
+        $filter = trim($filter);
+        // todo use smarter regex
+        // handle logical operators first
+        $logicalOperators = DbLogicalOperators::getDefinedConstants();
+        foreach ($logicalOperators as $logicalOp) {
+            if (DbLogicalOperators::NOT_STR === $logicalOp) {
+                // NOT(a = 1)  or NOT (a = 1)format
+                if ((0 === stripos($filter, $logicalOp . ' (')) || (0 === stripos($filter, $logicalOp . '('))) {
+                    $parts = trim(substr($filter, 3));
+                    $parts = $this->parseFilterString($parts, $out_params, $fields_info, $in_params);
+
+                    return static::localizeOperator($logicalOp) . $parts;
+                }
+            } else {
+                // (a = 1) AND (b = 2) format or (a = 1)AND(b = 2) format
+                $filter = str_ireplace(')' . $logicalOp . '(', ') ' . $logicalOp . ' (', $filter);
+                $paddedOp = ') ' . $logicalOp . ' (';
+                if (false !== $pos = stripos($filter, $paddedOp)) {
+                    $left = trim(substr($filter, 0, $pos)) . ')'; // add back right )
+                    $right = '(' . trim(substr($filter, $pos + strlen($paddedOp))); // adding back left (
+                    $left = $this->parseFilterString($left, $out_params, $fields_info, $in_params);
+                    $right = $this->parseFilterString($right, $out_params, $fields_info, $in_params);
+
+                    return $left . ' ' . static::localizeOperator($logicalOp) . ' ' . $right;
+                }
+            }
+        }
+
+        $wrap = false;
+        if ((0 === strpos($filter, '(')) && ((strlen($filter) - 1) === strrpos($filter, ')'))) {
+            // remove unnecessary wrapping ()
+            $filter = substr($filter, 1, -1);
+            $wrap = true;
+        }
+
+        // Some scenarios leave extra parens dangling
+        $pure = trim($filter, '()');
+        $pieces = explode($pure, $filter);
+        $leftParen = (!empty($pieces[0]) ? $pieces[0] : null);
+        $rightParen = (!empty($pieces[1]) ? $pieces[1] : null);
+        $filter = $pure;
+
+        // the rest should be comparison operators
+        // Note: order matters here!
+        $sqlOperators = DbComparisonOperators::getParsingOrder();
+        foreach ($sqlOperators as $sqlOp) {
+            $paddedOp = static::padOperator($sqlOp);
+            if (false !== $pos = stripos($filter, $paddedOp)) {
+                $field = trim(substr($filter, 0, $pos));
+                $negate = false;
+                if (false !== strpos($field, ' ')) {
+                    $parts = explode(' ', $field);
+                    $partsCount = count($parts);
+                    if (($partsCount > 1) &&
+                        (0 === strcasecmp($parts[$partsCount - 1], trim(DbLogicalOperators::NOT_STR)))
+                    ) {
+                        // negation on left side of operator
+                        array_pop($parts);
+                        $field = implode(' ', $parts);
+                        $negate = true;
+                    }
+                }
+                /** @type ColumnSchema $info */
+                if (null === $info = array_get($fields_info, strtolower($field))) {
+                    // This could be SQL injection attempt or bad field
+                    throw new BadRequestException("Invalid or unparsable field in filter request: '$field'");
+                }
+
+                // make sure we haven't chopped off right side too much
+                $value = trim(substr($filter, $pos + strlen($paddedOp)));
+                if ((0 !== strpos($value, "'")) &&
+                    (0 !== $lpc = substr_count($value, '(')) &&
+                    ($lpc !== $rpc = substr_count($value, ')'))
+                ) {
+                    // add back to value from right
+                    $parenPad = str_repeat(')', $lpc - $rpc);
+                    $value .= $parenPad;
+                    $rightParen = preg_replace('/\)/', '', $rightParen, $lpc - $rpc);
+                }
+                if (DbComparisonOperators::requiresValueList($sqlOp)) {
+                    if ((0 === strpos($value, '(')) && ((strlen($value) - 1) === strrpos($value, ')'))) {
+                        // remove wrapping ()
+                        $value = substr($value, 1, -1);
+                        $parsed = [];
+                        foreach (explode(',', $value) as $each) {
+                            $parsed[] = $this->parseFilterValue(trim($each), $info, $out_params, $in_params);
+                        }
+                        $value = '(' . implode(',', $parsed) . ')';
+                    } else {
+                        throw new BadRequestException('Filter value lists must be wrapped in parentheses.');
+                    }
+                } elseif (DbComparisonOperators::requiresNoValue($sqlOp)) {
+                    $value = null;
+                } else {
+                    static::modifyValueByOperator($sqlOp, $value);
+                    $value = $this->parseFilterValue($value, $info, $out_params, $in_params);
+                }
+
+                $sqlOp = static::localizeOperator($sqlOp);
+                if ($negate) {
+                    $sqlOp = DbLogicalOperators::NOT_STR . ' ' . $sqlOp;
+                }
+
+                if ($function = $info->getDbFunction(DbFunctionUses::FILTER)) {
+                    $out = $this->parent->getConnection()->raw($function);
+                } else {
+                    $out = $info->quotedName;
+                }
+                $out .= " $sqlOp";
+                $out .= (isset($value) ? " $value" : null);
+                if ($leftParen) {
+                    $out = $leftParen . $out;
+                }
+                if ($rightParen) {
+                    $out .= $rightParen;
+                }
+
+                return ($wrap ? '(' . $out . ')' : $out);
+            }
+        }
+
+        // This could be SQL injection attempt or unsupported filter arrangement
+        throw new BadRequestException('Invalid or unparsable filter request.');
     }
 
     /**


### PR DESCRIPTION
This PR adds support for Snowflake's ILIKE operator for case-insensitive matching in the filter field. It works well from my testing. I don't love that I had to duplicate the parseFilterString function in the SnowflakeTable class, but I could not figure out another way to override the DbComparisonOperators with my new Snowflake specific one.  I am open to suggestions on this to improve the code quality, but this still seems to work well in any case.