### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,16 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-sqldb": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Database/Schema/SnowflakeSchema.php
+++ b/src/Database/Schema/SnowflakeSchema.php
@@ -263,18 +263,30 @@ SQL;
             $dbNamePrefix = $this->quoteTableName($holder->databaseName) . '.';
         }
  
+        // Both {$type} columns and the dbNamePrefix come from non-caller
+        // sources (the holder is hydrated from a prior schema query). The
+        // routine name and schema, however, originate from caller-supplied
+        // route parameters, so they must be parameterized.
         $sql = <<<MYSQL
-SELECT * FROM {$dbNamePrefix}INFORMATION_SCHEMA.{$type}S WHERE {$type}_NAME = '{$holder->resourceName}' AND {$type}_SCHEMA = '{$holder->schemaName}'
+SELECT * FROM {$dbNamePrefix}INFORMATION_SCHEMA.{$type}S WHERE {$type}_NAME = :name AND {$type}_SCHEMA = :schema
 MYSQL;
 
-        $bindings = [':object' => $type, ':schema' => $holder->schemaName];
- 
+        $bindings = [
+            ':name'   => $holder->resourceName,
+            ':schema' => $holder->schemaName,
+        ];
+
         $rows = $this->connection->select($sql, $bindings);
         foreach ($rows as $row) {
             $row = array_change_key_case((array)$row, CASE_UPPER);
-            $argumentSignature = str_replace(['(', ')'], '"', Arr::get($row, 'ARGUMENT_SIGNATURE'));
-            $arguments = [];
-            eval('$arguments = explode( ", ", ' . $argumentSignature . ');');
+            // Snowflake ARGUMENT_SIGNATURE is shaped like "(VARCHAR, INT)";
+            // strip parens and split on comma. Previous code used eval() on
+            // the str_replace'd string — full RCE if a routine author could
+            // smuggle PHP syntax into ARGUMENT_SIGNATURE.
+            $argumentSignature = trim((string) Arr::get($row, 'ARGUMENT_SIGNATURE'), '()');
+            $arguments = $argumentSignature === ''
+                ? []
+                : array_map('trim', explode(',', $argumentSignature));
             foreach ($arguments as $key => $value) {
                 $pos = intval($key + 1);
                 // parse ARGUMENT_SIGNATURE

--- a/src/Database/SnowflakeConnection.php
+++ b/src/Database/SnowflakeConnection.php
@@ -104,7 +104,7 @@ class SnowflakeConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return new SnowflakeGrammar;
+        return new SnowflakeGrammar($this);
     }
 
     /**
@@ -124,7 +124,7 @@ class SnowflakeConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar());
+        return new SchemaGrammar($this);
     }
 
     /**

--- a/tests/Security/SnowflakeLoadParametersTest.php
+++ b/tests/Security/SnowflakeLoadParametersTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace DreamFactory\Core\Snowflake\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: SnowflakeSchema::loadParameters() must NOT use eval() and must
+ * parameterize the information-schema lookup.
+ *
+ * Phase 2 audit (df-snowflake P0/P1) found:
+ *
+ *   1. SQL string interpolated `$holder->resourceName` and `$holder->schemaName`
+ *      directly into the WHERE clause:
+ *         WHERE {$type}_NAME = '{$holder->resourceName}' AND {$type}_SCHEMA = '{$holder->schemaName}'
+ *
+ *   2. The ARGUMENT_SIGNATURE returned from Snowflake was passed to eval():
+ *         $argumentSignature = str_replace(['(', ')'], '"', ...);
+ *         eval('$arguments = explode( ", ", ' . $argumentSignature . ');');
+ *
+ *      The str_replace converts `(...)` to `"..."` but does NOT escape
+ *      embedded PHP metacharacters. A routine author who can craft an
+ *      ARGUMENT_SIGNATURE that contains PHP syntax (closing the string,
+ *      injecting code) gets remote code execution in the DreamFactory
+ *      process.
+ *
+ * After the fix:
+ *   1. WHERE clause uses :name and :schema bindings.
+ *   2. ARGUMENT_SIGNATURE is split via trim('()') + explode(',') — no eval.
+ */
+class SnowflakeLoadParametersTest extends TestCase
+{
+    private string $sourcePath;
+    private string $contents;
+
+    protected function setUp(): void
+    {
+        $this->sourcePath = __DIR__ . '/../../src/Database/Schema/SnowflakeSchema.php';
+        $this->assertFileExists($this->sourcePath);
+        $this->contents = file_get_contents($this->sourcePath);
+    }
+
+    private function loadParametersBody(): string
+    {
+        $start = strpos($this->contents, 'function loadParameters');
+        $this->assertNotFalse($start, 'loadParameters() must exist');
+        $next = strpos($this->contents, "\n    /**", $start + 10);
+        if ($next === false) {
+            $next = strpos($this->contents, "\n    public function ", $start + 10);
+        }
+        if ($next === false) {
+            $next = strpos($this->contents, "\n    protected function ", $start + 10);
+        }
+        return substr($this->contents, $start, $next === false ? null : ($next - $start));
+    }
+
+    public function testLoadParametersDoesNotUseEval(): void
+    {
+        $body = $this->loadParametersBody();
+        // Strip line/block comments before checking — the `eval` keyword may
+        // appear in a comment explaining the previous behaviour.
+        $stripped = preg_replace('!//[^\n]*!', '', $body);
+        $stripped = preg_replace('!/\*.*?\*/!s', '', $stripped);
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/\beval\s*\(/',
+            $stripped,
+            'loadParameters() must not use eval(). Use trim/explode to parse '
+            . 'ARGUMENT_SIGNATURE without invoking the PHP parser on data.'
+        );
+    }
+
+    public function testLoadParametersParameterizesRoutineAndSchema(): void
+    {
+        $body = $this->loadParametersBody();
+
+        $this->assertDoesNotMatchRegularExpression(
+            "/'\{\\\$holder->resourceName\}'/",
+            $body,
+            'loadParameters() must not interpolate $holder->resourceName into SQL'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            "/'\{\\\$holder->schemaName\}'/",
+            $body,
+            'loadParameters() must not interpolate $holder->schemaName into SQL'
+        );
+        $this->assertMatchesRegularExpression(
+            '/:(name|routineName)\b/',
+            $body,
+            'loadParameters() must use a :name (or :routineName) named placeholder'
+        );
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
