### PR TITLE
Snowflake connector quick wins: query tagging, rollback, session params, auth fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,112 @@
 # df-snowflake
 DreamFactory Snowflake Database Service
 
-This code is governed by a commercial license. To use it, you must follow refer to the LICENSE file.
-
+This code is governed by a commercial license. To use it, refer to the LICENSE file.
 
 ## Overview
 
 DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.
 
+This package connects DreamFactory to Snowflake via the official Snowflake PHP PDO driver (`pdo_snowflake`) — a compiled C extension that speaks Snowflake's native protocol. One connection per service instance per HTTP request (no pooling).
+
+## Requirements
+
+- **Gold license** — the Snowflake service type is only available on Gold tier.
+- The `pdo_snowflake` PHP extension must be installed and loaded. Confirm with `php -m | grep snowflake`. It ships in the official DreamFactory Docker images.
+
 ## Configure Snowflake
 
-To connect your Snowflake database to Dreamfactory, you will need to specify:
+Create the service in the admin console: **Services > Create > Database > Snowflake**, then fill the config form:
 
-1) Hostname
-An optional hostname that can be used as an alternative to the snowflake default hostname.
-2) Account
-Account is the [hostname + region](https://docs.snowflake.com/en/user-guide/intro-regions.html#specifying-region-information-in-your-account-hostname) information.  
-You can just copy it from your snowflake database URL:  
+| Field | Required | Notes |
+|-------|----------|-------|
+| Account | Yes | Snowflake [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier) (e.g. `xy12345.us-east-1` or the org-account form `MYORG-MYACCT`). Supports lookup keys. |
+| Hostname | No | Custom endpoint for PrivateLink or vanity URLs. Leave blank to derive the host from Account. |
+| Username | Yes | Snowflake user with access to the database. Supports lookup keys. |
+| Password | Conditional | Required for password auth. Leave blank for key-pair auth. |
+| Private Key File | Conditional | Upload/select a `.pem`/`.p8` file for key-pair auth. |
+| Private Key Passphrase | No | Only if the key file is encrypted. |
+| Role | No | Snowflake role to assume on connection. |
+| Database | Yes | Target database. Supports lookup keys. |
+| Warehouse | Yes | Compute warehouse. |
+| Schema | No | Defaults to `PUBLIC` (Snowflake's default schema) if left blank. |
 
-![accountexample](https://img.in6k.com/screens/3caa9f72_2021.04.02.png)
+`username`, `password`, `key`, and `passcode` are encrypted at rest; `password` is additionally masked (never returned in API responses).
 
+## Authentication
 
-3) Username
-Username that you use to login to your snowflake account or any other user with access to the database.
-4) Password
-Password for your snowflake account (only if not using key pair authentication).
-5) Database
-Name of the database you want to connect to.
-6) Warehouse
-Name of the warehouse your database uses.
-7) Schema (optional)
-Schema of the database, PUBLIC by default.
+### Key-pair (recommended)
 
-## Key Pair Authentication
+> **Heads up:** Snowflake is retiring single-factor password auth for `TYPE=SERVICE` users in **October 2026**. Use key-pair (or OAuth/PAT) for service accounts.
 
-DreamFactory supports Snowflake's key pair authentication method, which can be more secure than password-based authentication. To use key pair authentication:
-
-1. Generate a key pair for Snowflake authentication:
+1. Generate a key pair:
    ```
-   openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8
+   openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
    openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
    ```
+   (Omit `-nocrypt` to encrypt the private key; then set the passphrase in the config.)
 
-2. In Snowflake, assign the public key to your user:
+2. Register the public key on your Snowflake user (strip the PEM header/footer and all line breaks):
    ```sql
    ALTER USER <username> SET RSA_PUBLIC_KEY='<public_key_data>';
    ```
-   Replace `<public_key_data>` with the contents of your public key (rsa_key.pub), ensuring all line breaks are removed.
 
-3. In DreamFactory:
-   - Specify your Snowflake account, username, and other connection details
-   - Leave the password field blank
-   - Upload your private key file (rsa_key.p8) in the "Private Key File" field
-   - If your private key is encrypted, enter the passphrase in the "Private Key Passphrase" field
+3. In DreamFactory: fill Account/Username/Database/Warehouse/Schema, **leave Password blank**, upload the private key in **Private Key File**, and set the passphrase only if the key is encrypted.
 
-For more information about Snowflake key pair authentication, see the [official Snowflake documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth).
+DreamFactory generates the JWT internally via `pdo_snowflake` (`authenticator=SNOWFLAKE_JWT`). Private keys are stored at `storage/app/keys/snowflake/` with `0600` permissions.
+
+### Password
+
+Fill the Password field and leave the key fields blank. Standard PDO auth.
+
+## Session Parameters (Additional SQL Statements)
+
+The **Additional SQL Statements** config field runs an array of SQL statements on every connection, before any request. Use it to set session parameters:
+
+```
+ALTER SESSION SET TIMEZONE = 'UTC'
+ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = 300
+ALTER SESSION SET ROWS_PER_RESULTSET = 10000
+```
+
+Common uses: pinning `TIMEZONE` for consistent timestamp handling, capping runaway queries with a statement timeout, and bounding result size.
+
+## Query Tagging
+
+Every connection is automatically tagged so you can attribute Snowflake cost and usage per DreamFactory service. The tag is a JSON object set via `ALTER SESSION SET QUERY_TAG`:
+
+```json
+{"app":"dreamfactory","service":"<service name>","database":"...","schema":"...","warehouse":"..."}
+```
+
+Attribute usage by querying account usage:
+
+```sql
+SELECT query_tag, COUNT(*), SUM(credits_used_cloud_services)
+FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY
+WHERE query_tag ILIKE '%dreamfactory%'
+GROUP BY 1;
+```
+
+Tagging is best-effort — if it fails, the connection is unaffected.
+
+## Runtime Overrides (multi-tenant)
+
+Any connection field can be overridden per-request, letting one service definition serve multiple databases/schemas/warehouses:
+
+- **Headers:** `hostname`, `account`, `database`, `schema`, `warehouse`, `username`, `password`, `key`, `passcode`, `role`.
+- **URL query params:** same fields **except `key` and `passcode`** — key material is deliberately header-only so it never lands in URLs, logs, or referrers.
+
+Header values take precedence over URL params.
+
+## Supported Features
+
+- Create, read, and delete on tables (GET, POST, DELETE). PUT/PATCH updates are currently hidden from the API docs pending verification.
+- Schema introspection
+- Stored procedures and functions (cross-database via the `X-Database-Name` header)
+- Snowflake Cortex AI functions (COMPLETE, CLASSIFY_TEXT, SENTIMENT, etc.)
+- VARIANT/OBJECT/ARRAY columns auto-decoded from JSON
+- `ILIKE` filter operator
+- Parameterized queries throughout
+
+For more on Snowflake key-pair auth, see the [official Snowflake documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth).

--- a/src/Database/Connectors/SnowflakeConnector.php
+++ b/src/Database/Connectors/SnowflakeConnector.php
@@ -24,7 +24,37 @@ class SnowflakeConnector extends Connector implements ConnectorInterface
         $dsn = $this->getDsn($config);
         $connection = $this->createConnection($dsn, $config, $options);
 
+        $this->applyQueryTag($connection, $config);
+
         return $connection;
+    }
+
+    /**
+     * Tag the Snowflake session so query cost/usage can be attributed to this
+     * DreamFactory service in ACCOUNT_USAGE.QUERY_HISTORY. Best-effort: a
+     * tagging failure must never break an otherwise-healthy connection.
+     *
+     * @param \PDO  $pdo
+     * @param array $config
+     * @return void
+     */
+    protected function applyQueryTag($pdo, array $config)
+    {
+        try {
+            $tag = array_filter([
+                'app'       => 'dreamfactory',
+                'service'   => $config['name'] ?? null,
+                'database'  => $config['database'] ?? null,
+                'schema'    => $config['schema'] ?? null,
+                'warehouse' => $config['warehouse'] ?? null,
+            ], fn ($v) => $v !== null && $v !== '');
+
+            // Snowflake string literals quote single-quotes by doubling them.
+            $json = str_replace("'", "''", json_encode($tag));
+            $pdo->exec("ALTER SESSION SET QUERY_TAG = '{$json}'");
+        } catch (\PDOException $e) {
+            \Log::warning('Snowflake QUERY_TAG could not be set: ' . $e->getMessage());
+        }
     }
 
     public function createConnection($dsn, array $config, array $options)
@@ -33,8 +63,16 @@ class SnowflakeConnector extends Connector implements ConnectorInterface
             $config['username'] ?? null, $config['password'] ?? null,
         ];
 
+        // The config UI can leave password as "" (not null) when key-pair auth
+        // is selected. Normalize an empty password to null so the branch below
+        // chooses key-pair auth when a key is present, instead of falling
+        // through to password auth with an empty password.
+        if ($password === '') {
+            $password = null;
+        }
+
         try {
-            if ($password === null && $config['key'] !== null) {
+            if ($password === null && !empty($config['key'])) {
                 return $this->createConnectionWithKeyPairAuth(
                     $dsn, $username, $config, $options
                 );
@@ -155,11 +193,11 @@ class SnowflakeConnector extends Connector implements ConnectorInterface
             $dsn .= "database={$database};";
         }
 
-        if (!empty($schema)) {
-            $dsn .= "schema={$schema};";
-        } else {
-            throw new \InvalidArgumentException("Schema not given, required.");
-        }
+        // Schema is required in the Snowflake DSN. Default to PUBLIC (Snowflake's
+        // own default schema) when the admin leaves it blank — matches the config
+        // field hint ("Leave blank to work with the default schema") instead of
+        // throwing on an otherwise-valid connection.
+        $dsn .= "schema=" . (!empty($schema) ? $schema : 'PUBLIC') . ";";
 
         if (!empty($warehouse)) {
             $dsn .= "warehouse={$warehouse};";

--- a/src/Models/SnowflakeDbConfig.php
+++ b/src/Models/SnowflakeDbConfig.php
@@ -104,18 +104,16 @@ class SnowflakeDbConfig extends BaseSqlDbConfig
     public static function getConfigSchema()
     {
         $schema = parent::getConfigSchema();
-        $cacheTtl = array_pop($schema);
-        $cacheEnabled = array_pop($schema);
-        $maxRecords = array_pop($schema);
-        $upserts = array_pop($schema);
-        array_pop($schema);                 // Remove statement
-        array_pop($schema);                 // Remove attributes
-        array_pop($schema);                 // Remove options
-        array_push($schema, $upserts);      // Restore upsert
-        array_push($schema, $maxRecords);   // Restore max_records
-        array_push($schema, $cacheEnabled); // Restore cache enabled
-        array_push($schema, $cacheTtl);     // Restore cache TTL
 
-        return $schema;
+        // Snowflake's pdo_snowflake driver doesn't honor PDO driver options or
+        // post-connect attributes, so drop those two fields. Keep `statements`
+        // so admins can issue session parameters on connect (e.g.
+        // `ALTER SESSION SET TIMEZONE = 'UTC'`, QUERY_TIMEOUT,
+        // ROWS_PER_RESULTSET) — the base SqlDb service already runs them via
+        // initStatements(). Name-based filter so base field-order changes can't
+        // silently strip the wrong field, as the old positional array_pop did.
+        return array_values(array_filter($schema, function ($field) {
+            return !in_array($field['name'] ?? null, ['options', 'attributes'], true);
+        }));
     }
 }

--- a/src/Resources/SnowflakeTable.php
+++ b/src/Resources/SnowflakeTable.php
@@ -263,12 +263,4 @@ class SnowflakeTable extends Table
         // This could be SQL injection attempt or unsupported filter arrangement
         throw new BadRequestException('Invalid or unparsable filter request.');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function rollbackTransaction()
-    {
-        // TODO: Implement rollbackTransaction() method.
-    }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -84,8 +84,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->substituteConfig('warehouse', 'url', $config);
         $this->substituteConfig('username', 'url', $config);
         $this->substituteConfig('password', 'url', $config);
-        $this->substituteConfig('key', 'header', $config);
-        $this->substituteConfig('passcode', 'header', $config);
+        // key/passcode are intentionally NOT overridable via URL query params —
+        // key material must not land in URLs (logs, history, referrers). They
+        // are still overridable via headers; checkHeaders() handles that.
         $this->substituteConfig('role', 'url', $config);
     }
 


### PR DESCRIPTION
Backend-only changes to `df-snowflake`, each **live-verified against a real Snowflake account** (`pdo_snowflake` in the dev container, both password and key-pair auth paths). No UI changes required — the admin form is schema-driven and already renders every field involved.

## Changes

- **Query tagging** — set `QUERY_TAG` on connect (`app`/`service`/`database`/`schema`/`warehouse`) so usage can be attributed in `ACCOUNT_USAGE.QUERY_HISTORY`. Best-effort; a tagging failure never breaks the connection.
- **Rollback fix** — deleted the empty `rollbackTransaction()` override that was *shadowing* the working df-sqldb base method and silently no-op'ing every rollback. Deletion restores the tested base impl (begin/commit were already inherited).
- **Session parameters** — stopped stripping the `statements` config field. The base `SqlDb` service already executes it on connect via `initStatements()`; the field was only hidden from the admin schema. Also replaced the fragile positional `array_pop` juggling with a name-based filter (drops only `options`/`attributes`).
- **Auth** — normalize empty-string password to `null` so key-pair auth is chosen when a key is present (fixes the null-vs-empty-string ambiguity from the config UI).
- **Schema default** — default to `PUBLIC` when left blank instead of throwing `InvalidArgumentException`, matching the config field's own hint.
- **ServiceProvider** — dropped the redundant header re-read for `key`/`passcode` in `checkUrlParams`; documented that they are header-only by design (never in URLs).
- **README** — documented requirements, corrected field table, key-pair/password auth, session parameters, query tagging, and runtime overrides.

## Verification

Live against account (password + key-pair):
- Query tag reads back exactly as set
- `ALTER SESSION SET TIMEZONE` takes effect (proves `statements`)
- Rollback: 3 rows mid-txn → 0 after
- Empty-password + key routed to key-pair JWT via the actual `SnowflakeConnector` class
- Blank schema → `CURRENT_SCHEMA() = PUBLIC`

Admin UI confirmed to render the re-enabled `statements` field (`df-array-field`, editable string list) and the `file_certificate_api` key picker — no UI change needed.

## Not included (deferred)

- 1.1 UI polish (key-pair-primary field order + Oct-2026 password deprecation banner) — genuinely UI-side, coordinate with the df-admin-interface session.
- 3.x (enable PUT/PATCH, grammar overrides, semi-structured) — separate effort.